### PR TITLE
Remove s3_conn_id named param and repair s3_key jinja templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This plugin moves data from the [Stripe](https://stripe.com/docs/api) API to S3 based on the specified object
 ## Creating a connection
-To create a connection with stripe using the Airflow UI you need to open the interface > Admin dropdown menu > click on "connections" > create. In "extras" field, specify your api key from stripe in the following format:
+
+1. To create a connection with stripe using the Airflow UI you need to open the interface > Admin dropdown menu > click on "connections" > create. In "extras" field, specify your api key from stripe in the following format:
 ``` {"api_key": "your_secret_api_key"} ```
-Leave all the other fields blank. 
+Leave all the other fields blank.
+2. To create a connection from an environment variable append the `api_key` to the Stripe API URL as a querystring parameter.
+
+        export AIRFLOW_CONN_STRIPE_DEFAULT=https://api.stripe.com?api_key=rk_live_yourstripeapikey
 
 ## Hooks
 ### StripeHook

--- a/operators/stripe_to_s3_operator.py
+++ b/operators/stripe_to_s3_operator.py
@@ -57,7 +57,7 @@ class StripeToS3Operator(BaseOperator, SkipMixin):
     :type replication_key_value:    String
     """
 
-    template_field = ('s3_key', )
+    template_fields = ("s3_key", )
 
     @apply_defaults
     def __init__(self,
@@ -122,7 +122,7 @@ class StripeToS3Operator(BaseOperator, SkipMixin):
                 return True
 
             else:
-                dest_s3 = S3Hook(s3_conn_id=self.s3_conn_id)
+                dest_s3 = S3Hook(self.s3_conn_id)
                 dest_s3.load_file(
                     filename=tmp.name,
                     key=self.s3_key,
@@ -130,7 +130,6 @@ class StripeToS3Operator(BaseOperator, SkipMixin):
                     replace=True
 
                 )
-                dest_s3.connection.close()
                 tmp.close()
 
     def filter_fields(self, result):


### PR DESCRIPTION
Minor bug fixes in the `StripeToS3Operator` for Airflow 1.10:

1. `template_field` should be `template_fields`.
2. `S3Hook` no longer has a named parameter for the `s3_conn_id`.
3. `S3Hook.connection` no longer has `close` method.
4. Add environment variable connection definition example in README.